### PR TITLE
Update etcd-registry version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "repository": "git://github.com/mafintosh/etcd-registry-router.git",
   "dependencies": {
     "pump": "~0.2.3",
-    "etcd-registry": "~1.1.0"
+    "etcd-registry": "~2.0.0"
   }
 }


### PR DESCRIPTION
`etcd-registry` introduces a breaking change, where the `refresh` option defaults to `false`.
